### PR TITLE
Add due count to taskbar icon

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -199,7 +199,7 @@ class AnkiSystemTray:
             # calculate this then
             return 0
 
-        tree = mw.col.sched.deck_due_tree()
+        tree = self.mw.col.sched.deck_due_tree()
         children = tree.children
 
         total = 0

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -84,13 +84,19 @@ class AnkiSystemTray:
             w.hide()
         self.isMinimizedToTray = True
 
-    def updateSystemTrayIcon(self):
-        self._updateSystemTrayIcon(self.trayIcon)
+    _displayedNumberOfCardsDue = 0
+    def updateSystemTrayIcon(self, force = False):
+        numberOfCardsDue = self._getAmountOfCardsDue()
+
+        if numberOfCardsDue != self._displayedNumberOfCardsDue or force:
+            self._displayedNumberOfCardsDue = numberOfCardsDue
+            self._setSystemTrayIcon(self.trayIcon, numberOfCardsDue)
 
     def _addHooks(self):
         updateFunction = lambda *args : self.updateSystemTrayIcon()
+        forceUpdateFunction = lambda *args : self.updateSystemTrayIcon(True)
 
-        gui_hooks.theme_did_change.append(updateFunction)
+        gui_hooks.theme_did_change.append(forceUpdateFunction)
         gui_hooks.state_did_change.append(updateFunction)
         gui_hooks.operation_did_execute.append(updateFunction)
 
@@ -194,8 +200,7 @@ class AnkiSystemTray:
     def _getCardsDueDisplayNumber(self, amount):
         return self._formatNumber(amount)
         
-    def _updateSystemTrayIcon(self, trayIcon):
-        numberOfReviews = self._getAmountOfCardsDue()
+    def _setSystemTrayIcon(self, trayIcon, numberOfReviews):
         displayNumber = self._getCardsDueDisplayNumber(numberOfReviews)
         shouldShowNumber = numberOfReviews > 0
 
@@ -205,7 +210,8 @@ class AnkiSystemTray:
     def _createSystemTrayIcon(self):
         trayIcon = QSystemTrayIcon(self.mw)
 
-        self._updateSystemTrayIcon(trayIcon)
+        numberOfReviews = self._getAmountOfCardsDue()
+        self._setSystemTrayIcon(trayIcon, numberOfReviews)
 
         trayMenu = QMenu(self.mw)
         trayIcon.setContextMenu(trayMenu)

--- a/src/config.json
+++ b/src/config.json
@@ -1,1 +1,5 @@
-{"hide_on_startup": false} 
+{
+  "hide_on_startup": false,
+  "show_due": true,
+  "due_font_size": 14
+}

--- a/src/config.json
+++ b/src/config.json
@@ -1,5 +1,5 @@
 {
-  "hide_on_startup": false,
-  "show_due": true,
-  "due_font_size": 14
+	"hide_on_startup": false,
+	"show_due": true,
+	"due_font_size": 16
 }


### PR DESCRIPTION
This adds a number for the amount of cards due to the taskbar icon, like in #3.

![image](https://github.com/user-attachments/assets/e165686c-4126-4d39-8506-15e5259e6d43)

The algorithm to determine the amount of cards due is based on [the code for AnkiDroid's widget](https://github.com/ankidroid/Anki-Android/blob/b1a27590d6822e5c3a8d7b37b4fbb82abb302aec/AnkiDroid/src/main/java/com/ichi2/widget/WidgetStatus.kt#L94). So, it counts only the amount of cards due for decks that aren't in any folders. Any subdecks won't be counted, even if they contain cards that are due. ([Screenshot](https://github.com/user-attachments/assets/354dcb01-7363-4135-85b8-6b97f975a125))

When there aren't any cards due, it'll just be the Anki logo.

It also pulls from Anki's theme to determine the color. Light mode and even AnKing's ReColor add-on work.

It supports and will shorten numbers to make it fit, up to 9,999. Past that point, it shows an infinity symbol as a placeholder.
